### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/adrifer/e61127bf-1941-4866-aa95-98b1906a0287/58160850-21f4-43f9-acd5-8f9648ddf3d6/_apis/work/boardbadge/ac07f6e7-ee5d-460b-bb33-636e960a6d99)](https://codedev.ms/adrifer/e61127bf-1941-4866-aa95-98b1906a0287/_boards/board/t/58160850-21f4-43f9-acd5-8f9648ddf3d6/Microsoft.RequirementCategory)
 # test1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/adrifer/e61127bf-1941-4866-aa95-98b1906a0287/_workitems/edit/1)