### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/adrifer/561c5d79-6a02-4089-9a09-8def7455321d/c6c041d6-d34e-4684-877e-bea4be7cc8b5/_apis/work/boardbadge/e2983250-eb63-4bbc-b6d1-6c2f971abc52)](https://dev.azure.com/adrifer/561c5d79-6a02-4089-9a09-8def7455321d/_boards/board/t/c6c041d6-d34e-4684-877e-bea4be7cc8b5/Microsoft.RequirementCategory)
 # test1
 The amazing project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/adrifer/561c5d79-6a02-4089-9a09-8def7455321d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.